### PR TITLE
feat: add Mintlify docs in apps/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ out
 # generated outputs (graph.json, summary, agents, diagrams)
 .devgraph/
 # internal docs (specs, marketing, brand)
-docs/
+internal-docs/
 dist
 *.tsbuildinfo
 .DS_Store

--- a/apps/docs/blocks/api.mdx
+++ b/apps/docs/blocks/api.mdx
@@ -1,0 +1,101 @@
+---
+title: devgraph-api
+description: "Define API routes for a service"
+---
+
+## Overview
+
+The `devgraph-api` block defines API routes for a service. Routes are associated with a parent service defined by `devgraph-service`.
+
+## Syntax
+
+````yaml
+```devgraph-api
+service: my-service
+routes:
+  GET /health: Health check endpoint
+  GET /api/users: List all users
+  POST /api/users: Create a new user
+  PUT /api/users/:id: Update a user
+  DELETE /api/users/:id: Delete a user
+```
+````
+
+## Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `service` | Yes | Name of the parent service |
+| `routes` | Yes | Object mapping routes to descriptions |
+
+## Route Format
+
+Routes are defined as `METHOD /path: description`:
+
+```yaml
+routes:
+  GET /path: Description of what this endpoint does
+  POST /path: Another endpoint description
+```
+
+### Supported Methods
+
+- `GET`
+- `POST`
+- `PUT`
+- `PATCH`
+- `DELETE`
+
+### Path Parameters
+
+Use `:param` syntax for path parameters:
+
+```yaml
+routes:
+  GET /users/:id: Get user by ID
+  PUT /posts/:postId/comments/:commentId: Update a comment
+```
+
+## Examples
+
+### REST API
+
+````yaml
+```devgraph-api
+service: api
+routes:
+  GET /health: Health check
+  GET /api/users: List users
+  GET /api/users/:id: Get user by ID
+  POST /api/users: Create user
+  PUT /api/users/:id: Update user
+  DELETE /api/users/:id: Delete user
+```
+````
+
+### Multiple API blocks
+
+You can split routes across multiple blocks:
+
+````yaml
+```devgraph-api
+service: api
+routes:
+  GET /api/users: List users
+  POST /api/users: Create user
+```
+
+```devgraph-api
+service: api
+routes:
+  GET /api/posts: List posts
+  POST /api/posts: Create post
+```
+````
+
+## Generated Output
+
+API routes appear in:
+- `graph.json` under the service's `api` field
+- `summary.md` in the routes table
+- `agents/{service}.md` context file

--- a/apps/docs/blocks/env.mdx
+++ b/apps/docs/blocks/env.mdx
@@ -1,0 +1,109 @@
+---
+title: devgraph-env
+description: "Define environment variables for a service"
+---
+
+## Overview
+
+The `devgraph-env` block defines environment variables for a service. Variables are associated with a parent service defined by `devgraph-service`.
+
+## Syntax
+
+````yaml
+```devgraph-env
+service: my-service
+vars:
+  PORT: "3000"
+  DATABASE_URL: postgresql://localhost:5432/mydb
+  NODE_ENV: development
+```
+````
+
+## Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `service` | Yes | Name of the parent service |
+| `vars` | Yes | Object mapping variable names to values |
+
+## Examples
+
+### Basic environment
+
+````yaml
+```devgraph-env
+service: api
+vars:
+  PORT: "3000"
+  NODE_ENV: development
+```
+````
+
+### Database configuration
+
+````yaml
+```devgraph-env
+service: api
+vars:
+  DATABASE_URL: postgresql://localhost:5432/mydb
+  DATABASE_POOL_SIZE: "10"
+  DATABASE_SSL: "false"
+```
+````
+
+### External services
+
+````yaml
+```devgraph-env
+service: api
+vars:
+  REDIS_URL: redis://localhost:6379
+  AWS_REGION: us-east-1
+  AWS_S3_BUCKET: my-bucket
+```
+````
+
+### Multiple env blocks
+
+You can split variables across multiple blocks:
+
+````yaml
+```devgraph-env
+service: api
+vars:
+  PORT: "3000"
+  NODE_ENV: development
+```
+
+```devgraph-env
+service: api
+vars:
+  DATABASE_URL: postgresql://localhost:5432/mydb
+```
+````
+
+## Security Note
+
+<Warning>
+  Do not include actual secrets in devgraph-env blocks. Use placeholder values or descriptions instead. These files are typically committed to version control.
+</Warning>
+
+Good:
+```yaml
+vars:
+  API_KEY: "your-api-key-here"
+  DATABASE_URL: postgresql://user:password@host:5432/db
+```
+
+Bad:
+```yaml
+vars:
+  API_KEY: "sk-live-abc123..."  # Never commit real secrets!
+```
+
+## Generated Output
+
+Environment variables appear in:
+- `graph.json` under the service's `env` field
+- `summary.md` in the environment table
+- `agents/{service}.md` context file

--- a/apps/docs/blocks/service.mdx
+++ b/apps/docs/blocks/service.mdx
@@ -1,0 +1,89 @@
+---
+title: devgraph-service
+description: "Define a service in your project"
+---
+
+## Overview
+
+The `devgraph-service` block defines a service in your project graph. This is the primary building block for DevGraph.
+
+## Syntax
+
+````yaml
+```devgraph-service
+name: my-service
+type: node
+commands:
+  dev: npm run dev
+  build: npm run build
+depends:
+  - other-service
+```
+````
+
+## Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique service identifier |
+| `type` | Yes | Service type (see below) |
+| `commands` | No | Object with command definitions |
+| `depends` | No | Array of service names this depends on |
+
+## Service Types
+
+| Type | Description |
+|------|-------------|
+| `node` | Node.js service |
+| `nextjs` | Next.js application |
+| `python` | Python service |
+| `go` | Go service |
+| `rust` | Rust service |
+| `database` | Database service |
+| `external` | External API or service |
+
+## Examples
+
+### Basic service
+
+````yaml
+```devgraph-service
+name: api
+type: node
+```
+````
+
+### Service with commands
+
+````yaml
+```devgraph-service
+name: web
+type: nextjs
+commands:
+  dev: pnpm dev
+  build: pnpm build
+  start: pnpm start
+```
+````
+
+### Service with dependencies
+
+````yaml
+```devgraph-service
+name: api
+type: node
+commands:
+  dev: npm run dev
+depends:
+  - database
+  - cache
+```
+````
+
+## Generated Output
+
+Services appear in:
+- `graph.json` as nodes
+- `summary.md` in the services table
+- `agents/{name}.md` as individual context files
+- `system.mmd` in the Mermaid diagram

--- a/apps/docs/cli/build.mdx
+++ b/apps/docs/cli/build.mdx
@@ -1,0 +1,55 @@
+---
+title: devgraph build
+description: "Build the project graph and generate outputs"
+---
+
+## Usage
+
+```bash
+devgraph build [paths...] [options]
+```
+
+## Arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `paths` | Glob patterns for Markdown files | `**/*.md` |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--compare <file>` | Compare with previous graph.json for diff |
+| `--help` | Show help |
+
+## Examples
+
+Build from all Markdown files in docs:
+
+```bash
+devgraph build docs/*.md
+```
+
+Build from multiple directories:
+
+```bash
+devgraph build docs/*.md architecture/*.md
+```
+
+Build with diff comparison:
+
+```bash
+devgraph build docs/*.md --compare .devgraph/graph.json
+```
+
+## Output
+
+Creates the following in `.devgraph/`:
+
+| File | Description |
+|------|-------------|
+| `graph.json` | Machine-readable project graph |
+| `summary.md` | Human-readable overview with tables |
+| `agents/*.md` | Per-service context files for LLMs |
+| `system.mmd` | Mermaid diagram of service dependencies |
+| `codemap.mmd` | Mermaid diagram of repo structure |

--- a/apps/docs/cli/studio.mdx
+++ b/apps/docs/cli/studio.mdx
@@ -1,0 +1,54 @@
+---
+title: devgraph studio
+description: "Launch the visual graph viewer"
+---
+
+## Usage
+
+```bash
+devgraph studio
+```
+
+## Description
+
+Launches DevGraph Studio, an interactive web-based graph viewer at [http://localhost:9111](http://localhost:9111).
+
+## Features
+
+<CardGroup cols={2}>
+  <Card title="Interactive Graph" icon="diagram-project">
+    Visualize service dependencies with React Flow.
+  </Card>
+  <Card title="Node Details" icon="circle-info">
+    Click any node to view service info, commands, and dependencies.
+  </Card>
+  <Card title="Search" icon="magnifying-glass">
+    Find services quickly by name.
+  </Card>
+  <Card title="Type Filtering" icon="filter">
+    Filter nodes by service type (node, nextjs, python, etc.).
+  </Card>
+</CardGroup>
+
+## Prerequisites
+
+Before running Studio, build your graph:
+
+```bash
+devgraph build docs/*.md
+devgraph studio
+```
+
+Studio reads from `.devgraph/graph.json`.
+
+## Port
+
+Studio runs on port `9111` by default.
+
+## Screenshot
+
+Studio provides a clean, dark-themed interface for exploring your project architecture:
+
+- **Left panel**: Interactive graph with draggable nodes
+- **Right panel**: Selected service details
+- **Top bar**: Search and filter controls

--- a/apps/docs/cli/validate.mdx
+++ b/apps/docs/cli/validate.mdx
@@ -1,0 +1,48 @@
+---
+title: devgraph validate
+description: "Validate devgraph blocks without generating outputs"
+---
+
+## Usage
+
+```bash
+devgraph validate [paths...]
+```
+
+## Arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `paths` | Glob patterns for Markdown files | `**/*.md` |
+
+## Description
+
+Validates all `devgraph-*` blocks in your Markdown files without generating any output files. Useful for CI/CD pipelines or pre-commit hooks.
+
+## Examples
+
+Validate docs directory:
+
+```bash
+devgraph validate docs/*.md
+```
+
+Validate all Markdown files:
+
+```bash
+devgraph validate "**/*.md"
+```
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| `0` | All blocks valid |
+| `1` | Validation errors found |
+
+## What it validates
+
+- YAML syntax in all `devgraph-*` blocks
+- Required fields (`name`, `type` for services)
+- Service references in `devgraph-api` and `devgraph-env` blocks
+- Dependency references exist

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "DevGraph",
+  "colors": {
+    "primary": "#8B5CF6",
+    "light": "#A78BFA",
+    "dark": "#7C3AED"
+  },
+  "logo": {
+    "dark": "/logo.png",
+    "light": "/logo.png"
+  },
+  "favicon": "/favicon.png",
+  "navigation": {
+    "groups": [
+      {
+        "group": "Getting Started",
+        "pages": ["introduction", "quickstart"]
+      },
+      {
+        "group": "CLI Commands",
+        "pages": ["cli/build", "cli/validate", "cli/studio"]
+      },
+      {
+        "group": "Block Types",
+        "pages": ["blocks/service", "blocks/api", "blocks/env"]
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/ameyalambat128/devgraph",
+      "x": "https://x.com/lambatameya"
+    }
+  }
+}

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -1,0 +1,50 @@
+---
+title: Introduction
+description: "One graph. Every repo. Context for humans and AI."
+---
+
+# What is DevGraph?
+
+DevGraph is a universal context layer for codebases. It scans Markdown files for service definitions, builds a project graph, and generates outputs like `graph.json`, `summary.md`, and agent-specific context files.
+
+One command to map your entire architecture—for humans and AI alike.
+
+## Key Features
+
+<CardGroup cols={2}>
+  <Card title="Markdown-First" icon="file-lines">
+    Define services, APIs, and environment variables in fenced code blocks within your existing docs.
+  </Card>
+  <Card title="Visual Graph" icon="diagram-project">
+    Launch DevGraph Studio to explore your architecture interactively.
+  </Card>
+  <Card title="AI-Ready Outputs" icon="robot">
+    Generate per-service context files optimized for LLMs and AI agents.
+  </Card>
+  <Card title="Mermaid Diagrams" icon="sitemap">
+    Auto-generate dependency and codebase structure diagrams.
+  </Card>
+</CardGroup>
+
+## Generated Outputs
+
+When you run `devgraph build`, the following files are created in `.devgraph/`:
+
+| File | Description |
+|------|-------------|
+| `graph.json` | Machine-readable project graph |
+| `summary.md` | Human-readable overview with tables |
+| `agents/*.md` | Per-service context files for LLMs |
+| `system.mmd` | Mermaid diagram of service dependencies |
+| `codemap.mmd` | Mermaid diagram of repo structure |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Get up and running in 5 minutes.
+  </Card>
+  <Card title="CLI Commands" icon="terminal" href="/cli/build">
+    Learn all available commands.
+  </Card>
+</CardGroup>

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -1,0 +1,99 @@
+---
+title: Quickstart
+description: "Get started with DevGraph in 5 minutes"
+---
+
+## Installation
+
+Install DevGraph globally or use npx:
+
+<CodeGroup>
+```bash npm
+npm install -g devgraph
+```
+
+```bash pnpm
+pnpm add -g devgraph
+```
+
+```bash npx
+npx devgraph build docs/*.md
+```
+</CodeGroup>
+
+## 1. Add blocks to your Markdown
+
+In any `.md` file (e.g., `docs/architecture.md`), add devgraph blocks:
+
+```yaml
+## API Service
+
+```devgraph-service
+name: api
+type: node
+commands:
+  dev: npm run dev
+  build: npm run build
+depends:
+  - database
+```
+
+```devgraph-api
+service: api
+routes:
+  GET /health: Health check
+  GET /api/users: List users
+  POST /api/users: Create user
+```
+
+```devgraph-env
+service: api
+vars:
+  PORT: "3000"
+  DATABASE_URL: postgresql://localhost:5432/mydb
+```
+```
+
+## 2. Build the graph
+
+```bash
+devgraph build docs/*.md
+```
+
+## 3. Check outputs
+
+Outputs are generated in `.devgraph/`:
+
+```
+.devgraph/
+├── graph.json      # Machine-readable project graph
+├── summary.md      # Human-readable overview
+├── agents/         # Per-service context files
+│   └── api.md
+├── system.mmd      # Service dependency diagram
+└── codemap.mmd     # Repo structure diagram
+```
+
+## 4. Visualize with Studio
+
+Launch the interactive graph viewer:
+
+```bash
+devgraph studio
+```
+
+Opens at [http://localhost:9111](http://localhost:9111) with:
+- Interactive node exploration
+- Service details panel
+- Search and filter by type
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Block Types" icon="cube" href="/blocks/service">
+    Learn about all block types.
+  </Card>
+  <Card title="DevGraph Studio" icon="chart-network" href="/cli/studio">
+    Explore the visual graph viewer.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
- Create docs.json config with DevGraph branding
- Add introduction and quickstart pages
- Add CLI command docs (build, validate, studio)
- Add block type docs (service, api, env)
- Rename internal docs/ to internal-docs/ (gitignored)